### PR TITLE
Add basic LIDAR overlay

### DIFF
--- a/lib/lidar_provider.dart
+++ b/lib/lidar_provider.dart
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class LidarPoint {
+  /// Angle in degrees. Normalized to 0.1° increments between 0 and <360.
+  final double angle;
+  final double distance;
+
+  LidarPoint({required double angle, required this.distance})
+      : angle = (((angle % 360) * 10).round() / 10);
+}
+
+class LidarState {
+  final List<LidarPoint> points;
+  LidarState({required this.points});
+
+  LidarState copyWith({List<LidarPoint>? points}) {
+    return LidarState(points: points ?? this.points);
+  }
+}
+
+class LidarNotifier extends StateNotifier<LidarState> {
+  LidarNotifier() : super(LidarState(points: []));
+
+  void update(List<LidarPoint> points) {
+    state = state.copyWith(
+      points: [for (final p in points) LidarPoint(angle: p.angle, distance: p.distance)],
+    );
+  }
+}
+
+final lidarProvider =
+    StateNotifierProvider<LidarNotifier, LidarState>((ref) => LidarNotifier());

--- a/lib/screen/home.dart
+++ b/lib/screen/home.dart
@@ -13,6 +13,8 @@ import 'package:flutter_cluster_dashboard/screen/widgets/right_bar.dart';
 import 'package:flutter_cluster_dashboard/screen/widgets/gauges/speed_gauge_animation_wrapper.dart';
 import 'package:flutter_cluster_dashboard/screen/widgets/signals.dart';
 import 'package:flutter_cluster_dashboard/screen/widgets/turn_signal.dart';
+import 'package:flutter_cluster_dashboard/screen/widgets/lidar_display.dart';
+import 'package:flutter_cluster_dashboard/lidar_provider.dart';
 import 'package:flutter_cluster_dashboard/vehicle-signals/vss_client.dart';
 import 'package:flutter_cluster_dashboard/vehicle-signals/vss_provider.dart';
 import 'package:flutter_cluster_dashboard/vehicle-signals/vehicle_status_provider.dart';
@@ -31,6 +33,15 @@ class _HomeState extends ConsumerState<Home> {
   initState() {
     vss = ref.read(vssClientProvider);
     vss.run();
+
+    // Sample LIDAR data with 0.1° resolution
+    ref.read(lidarProvider.notifier).update([
+      LidarPoint(angle: 0.2, distance: 5),
+      LidarPoint(angle: 45.1, distance: 8),
+      LidarPoint(angle: 90.4, distance: 6),
+      LidarPoint(angle: 135.7, distance: 7),
+      LidarPoint(angle: 180.0, distance: 4),
+    ]);
 
     super.initState();
   }
@@ -116,6 +127,13 @@ class _HomeState extends ConsumerState<Home> {
                           screenHeight: screenHeight,
                           isLeftOn: isLeftIndicator,
                           isRightOn: isRightIndicator,
+                        ),
+                        Align(
+                          alignment: Alignment.topCenter,
+                          child: LidarDisplay(
+                            maxDistance: 10,
+                            size: (80 * screenHeight) / 480,
+                          ),
                         ),
                         Flex(
                           direction: Axis.horizontal,

--- a/lib/screen/widgets/lidar_display.dart
+++ b/lib/screen/widgets/lidar_display.dart
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+// Uses [LidarPoint] data quantized in 0.1° increments.
+import '../../lidar_provider.dart';
+
+class LidarDisplay extends ConsumerWidget {
+  final double maxDistance;
+  final double? size;
+  final Color backgroundColor;
+  const LidarDisplay({
+    Key? key,
+    required this.maxDistance,
+    this.size,
+    this.backgroundColor = const Color(0xFFB0BEC5), // light blue-grey
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final points = ref.watch(lidarProvider).points;
+    return SizedBox(
+      width: size,
+      height: size,
+      child: CustomPaint(
+        painter: _LidarPainter(
+          points: points,
+          maxDistance: maxDistance,
+          backgroundColor: backgroundColor,
+        ),
+      ),
+    );
+  }
+}
+
+class _LidarPainter extends CustomPainter {
+  final List<LidarPoint> points;
+  final double maxDistance;
+  final Color backgroundColor;
+
+  _LidarPainter({
+    required this.points,
+    required this.maxDistance,
+    required this.backgroundColor,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = min(size.width, size.height) / 2;
+
+    final fillPaint = Paint()
+      ..color = backgroundColor
+      ..style = PaintingStyle.fill;
+
+    final borderPaint = Paint()
+      ..color = Colors.grey
+      ..style = PaintingStyle.stroke;
+
+    canvas.drawCircle(center, radius, fillPaint);
+    canvas.drawCircle(center, radius, borderPaint);
+
+    final pointPaint = Paint()..color = Colors.green;
+
+    for (final p in points) {
+      final r = (p.distance / maxDistance) * radius;
+      final ang = p.angle * pi / 180;
+      final offset = Offset(
+        center.dx + r * cos(ang),
+        center.dy - r * sin(ang),
+      );
+      canvas.drawCircle(offset, 2.0, pointPaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _LidarPainter oldDelegate) {
+    return oldDelegate.points != points ||
+        oldDelegate.maxDistance != maxDistance ||
+        oldDelegate.backgroundColor != backgroundColor;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `LidarPoint` model and provider
- add `LidarDisplay` widget to paint polar data
- show sample LIDAR plot on the home screen
- quantize angles to 0.1°
- draw LIDAR background with a pale blue‑grey fill

## Testing
- `git status --short`
- `git log -1 --stat`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6853a66ab378832298cd5ff508e49983