### PR TITLE
Add LIDAR Kuksa support

### DIFF
--- a/lib/lidar_provider.dart
+++ b/lib/lidar_provider.dart
@@ -25,7 +25,8 @@ class LidarNotifier extends StateNotifier<LidarState> {
 
   /// Update the list of lidar points.
   void update(List<LidarPoint> points) {
-    state = state.copyWith(points: points);
+    print(points);
+    //state = state.copyWith(points: points);
   }
 }
 

--- a/lib/lidar_provider.dart
+++ b/lib/lidar_provider.dart
@@ -23,10 +23,9 @@ class LidarState {
 class LidarNotifier extends StateNotifier<LidarState> {
   LidarNotifier() : super(LidarState(points: []));
 
+  /// Update the list of lidar points.
   void update(List<LidarPoint> points) {
-    // Temporary debug output
-    // ignore: avoid_print
-    print(points);
+    state = state.copyWith(points: points);
   }
 }
 

--- a/lib/vehicle-signals/vss_path.dart
+++ b/lib/vehicle-signals/vss_path.dart
@@ -92,4 +92,8 @@ class VSSPath {
 
   static const String vehicleDestLon =
       "Vehicle.Cabin.Infotainment.Navigation.DestinationSet.Longitude";
+
+  // LIDAR signals
+  static const String lidarAngles = "Vehicle.ADAS.Lidar.Angles";
+  static const String lidarDistances = "Vehicle.ADAS.Lidar.Distances";
 }


### PR DESCRIPTION
## Summary
- store LIDAR points in `LidarState` using `LidarPoint`
- update home screen sample data
- build lidar messages into `LidarPoint` objects when receiving VSS updates

## Testing
- `dart format -o none --set-exit-if-changed lib/lidar_provider.dart lib/screen/home.dart lib/vehicle-signals/vss_provider.dart lib/vehicle-signals/vss_path.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c97368948322b054a15857583b93