### PR TITLE
Update Lidar CAN message encoding

### DIFF
--- a/simple-can-simulator.py
+++ b/simple-can-simulator.py
@@ -379,10 +379,13 @@ class LidarMessageSender(object):
                 angle, distance = self.data[idx % count]
                 if self.verbose:
                     print(f'lidar angle = {angle} distance = {distance}')
-                angle_raw = int(angle / 0.1)
-                distance_raw = int(distance / 0.01)
-                data = struct.pack('<II', angle_raw, distance_raw)
-                self.can_sock.send(0x219, data, 0)
+                # Convert to raw 16-bit values according to the DBC:
+                # LIDAR_Angle    : 0.01 deg/bit
+                # LIDAR_Distance : 0.001 m/bit
+                angle_raw = int(angle / 0.01)
+                distance_raw = int(distance / 0.001)
+                data = struct.pack('<HH', angle_raw, distance_raw)
+                self.can_sock.send(0x680, data, 0)
                 idx += 1
 
             # Wait before next batch


### PR DESCRIPTION
## Summary
- encode LIDAR data as 16-bit fields per dbc
- send LIDAR_Point on CAN ID `0x680`

## Testing
- `python3 -m py_compile simple-can-simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_6853e13685288322af284250186c36bc