### PR TITLE
Add lidar arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ app.*.map.json
 /android/app/release
 
 .desktop-homescreen
+flutter/

--- a/agl-vcar.dbc
+++ b/agl-vcar.dbc
@@ -94,3 +94,724 @@ BO_ 192 EPS_STATUS: 8 EPS
 BO_ 1664 LIDAR_Point: 8 Vector_XXX
   SG_ LIDAR_Angle : 0|16@1+ (0.01,0) [0|35999.99] "deg" Vector_XXX
   SG_ LIDAR_Distance : 16|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+
+BO_ 1664 LIDAR_Dist0: 8 Vector_XXX
+ SG_ LIDAR_Distance0 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1665 LIDAR_Dist1: 8 Vector_XXX
+ SG_ LIDAR_Distance1 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1666 LIDAR_Dist2: 8 Vector_XXX
+ SG_ LIDAR_Distance2 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1667 LIDAR_Dist3: 8 Vector_XXX
+ SG_ LIDAR_Distance3 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1668 LIDAR_Dist4: 8 Vector_XXX
+ SG_ LIDAR_Distance4 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1669 LIDAR_Dist5: 8 Vector_XXX
+ SG_ LIDAR_Distance5 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1670 LIDAR_Dist6: 8 Vector_XXX
+ SG_ LIDAR_Distance6 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1671 LIDAR_Dist7: 8 Vector_XXX
+ SG_ LIDAR_Distance7 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1672 LIDAR_Dist8: 8 Vector_XXX
+ SG_ LIDAR_Distance8 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1673 LIDAR_Dist9: 8 Vector_XXX
+ SG_ LIDAR_Distance9 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1674 LIDAR_Dist10: 8 Vector_XXX
+ SG_ LIDAR_Distance10 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1675 LIDAR_Dist11: 8 Vector_XXX
+ SG_ LIDAR_Distance11 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1676 LIDAR_Dist12: 8 Vector_XXX
+ SG_ LIDAR_Distance12 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1677 LIDAR_Dist13: 8 Vector_XXX
+ SG_ LIDAR_Distance13 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1678 LIDAR_Dist14: 8 Vector_XXX
+ SG_ LIDAR_Distance14 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1679 LIDAR_Dist15: 8 Vector_XXX
+ SG_ LIDAR_Distance15 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1680 LIDAR_Dist16: 8 Vector_XXX
+ SG_ LIDAR_Distance16 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1681 LIDAR_Dist17: 8 Vector_XXX
+ SG_ LIDAR_Distance17 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1682 LIDAR_Dist18: 8 Vector_XXX
+ SG_ LIDAR_Distance18 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1683 LIDAR_Dist19: 8 Vector_XXX
+ SG_ LIDAR_Distance19 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1684 LIDAR_Dist20: 8 Vector_XXX
+ SG_ LIDAR_Distance20 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1685 LIDAR_Dist21: 8 Vector_XXX
+ SG_ LIDAR_Distance21 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1686 LIDAR_Dist22: 8 Vector_XXX
+ SG_ LIDAR_Distance22 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1687 LIDAR_Dist23: 8 Vector_XXX
+ SG_ LIDAR_Distance23 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1688 LIDAR_Dist24: 8 Vector_XXX
+ SG_ LIDAR_Distance24 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1689 LIDAR_Dist25: 8 Vector_XXX
+ SG_ LIDAR_Distance25 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1690 LIDAR_Dist26: 8 Vector_XXX
+ SG_ LIDAR_Distance26 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1691 LIDAR_Dist27: 8 Vector_XXX
+ SG_ LIDAR_Distance27 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1692 LIDAR_Dist28: 8 Vector_XXX
+ SG_ LIDAR_Distance28 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1693 LIDAR_Dist29: 8 Vector_XXX
+ SG_ LIDAR_Distance29 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1694 LIDAR_Dist30: 8 Vector_XXX
+ SG_ LIDAR_Distance30 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1695 LIDAR_Dist31: 8 Vector_XXX
+ SG_ LIDAR_Distance31 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1696 LIDAR_Dist32: 8 Vector_XXX
+ SG_ LIDAR_Distance32 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1697 LIDAR_Dist33: 8 Vector_XXX
+ SG_ LIDAR_Distance33 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1698 LIDAR_Dist34: 8 Vector_XXX
+ SG_ LIDAR_Distance34 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1699 LIDAR_Dist35: 8 Vector_XXX
+ SG_ LIDAR_Distance35 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1700 LIDAR_Dist36: 8 Vector_XXX
+ SG_ LIDAR_Distance36 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1701 LIDAR_Dist37: 8 Vector_XXX
+ SG_ LIDAR_Distance37 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1702 LIDAR_Dist38: 8 Vector_XXX
+ SG_ LIDAR_Distance38 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1703 LIDAR_Dist39: 8 Vector_XXX
+ SG_ LIDAR_Distance39 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1704 LIDAR_Dist40: 8 Vector_XXX
+ SG_ LIDAR_Distance40 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1705 LIDAR_Dist41: 8 Vector_XXX
+ SG_ LIDAR_Distance41 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1706 LIDAR_Dist42: 8 Vector_XXX
+ SG_ LIDAR_Distance42 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1707 LIDAR_Dist43: 8 Vector_XXX
+ SG_ LIDAR_Distance43 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1708 LIDAR_Dist44: 8 Vector_XXX
+ SG_ LIDAR_Distance44 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1709 LIDAR_Dist45: 8 Vector_XXX
+ SG_ LIDAR_Distance45 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1710 LIDAR_Dist46: 8 Vector_XXX
+ SG_ LIDAR_Distance46 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1711 LIDAR_Dist47: 8 Vector_XXX
+ SG_ LIDAR_Distance47 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1712 LIDAR_Dist48: 8 Vector_XXX
+ SG_ LIDAR_Distance48 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1713 LIDAR_Dist49: 8 Vector_XXX
+ SG_ LIDAR_Distance49 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1714 LIDAR_Dist50: 8 Vector_XXX
+ SG_ LIDAR_Distance50 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1715 LIDAR_Dist51: 8 Vector_XXX
+ SG_ LIDAR_Distance51 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1716 LIDAR_Dist52: 8 Vector_XXX
+ SG_ LIDAR_Distance52 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1717 LIDAR_Dist53: 8 Vector_XXX
+ SG_ LIDAR_Distance53 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1718 LIDAR_Dist54: 8 Vector_XXX
+ SG_ LIDAR_Distance54 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1719 LIDAR_Dist55: 8 Vector_XXX
+ SG_ LIDAR_Distance55 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1720 LIDAR_Dist56: 8 Vector_XXX
+ SG_ LIDAR_Distance56 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1721 LIDAR_Dist57: 8 Vector_XXX
+ SG_ LIDAR_Distance57 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1722 LIDAR_Dist58: 8 Vector_XXX
+ SG_ LIDAR_Distance58 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1723 LIDAR_Dist59: 8 Vector_XXX
+ SG_ LIDAR_Distance59 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1724 LIDAR_Dist60: 8 Vector_XXX
+ SG_ LIDAR_Distance60 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1725 LIDAR_Dist61: 8 Vector_XXX
+ SG_ LIDAR_Distance61 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1726 LIDAR_Dist62: 8 Vector_XXX
+ SG_ LIDAR_Distance62 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1727 LIDAR_Dist63: 8 Vector_XXX
+ SG_ LIDAR_Distance63 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1728 LIDAR_Dist64: 8 Vector_XXX
+ SG_ LIDAR_Distance64 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1729 LIDAR_Dist65: 8 Vector_XXX
+ SG_ LIDAR_Distance65 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1730 LIDAR_Dist66: 8 Vector_XXX
+ SG_ LIDAR_Distance66 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1731 LIDAR_Dist67: 8 Vector_XXX
+ SG_ LIDAR_Distance67 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1732 LIDAR_Dist68: 8 Vector_XXX
+ SG_ LIDAR_Distance68 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1733 LIDAR_Dist69: 8 Vector_XXX
+ SG_ LIDAR_Distance69 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1734 LIDAR_Dist70: 8 Vector_XXX
+ SG_ LIDAR_Distance70 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1735 LIDAR_Dist71: 8 Vector_XXX
+ SG_ LIDAR_Distance71 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1736 LIDAR_Dist72: 8 Vector_XXX
+ SG_ LIDAR_Distance72 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1737 LIDAR_Dist73: 8 Vector_XXX
+ SG_ LIDAR_Distance73 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1738 LIDAR_Dist74: 8 Vector_XXX
+ SG_ LIDAR_Distance74 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1739 LIDAR_Dist75: 8 Vector_XXX
+ SG_ LIDAR_Distance75 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1740 LIDAR_Dist76: 8 Vector_XXX
+ SG_ LIDAR_Distance76 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1741 LIDAR_Dist77: 8 Vector_XXX
+ SG_ LIDAR_Distance77 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1742 LIDAR_Dist78: 8 Vector_XXX
+ SG_ LIDAR_Distance78 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1743 LIDAR_Dist79: 8 Vector_XXX
+ SG_ LIDAR_Distance79 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1744 LIDAR_Dist80: 8 Vector_XXX
+ SG_ LIDAR_Distance80 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1745 LIDAR_Dist81: 8 Vector_XXX
+ SG_ LIDAR_Distance81 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1746 LIDAR_Dist82: 8 Vector_XXX
+ SG_ LIDAR_Distance82 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1747 LIDAR_Dist83: 8 Vector_XXX
+ SG_ LIDAR_Distance83 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1748 LIDAR_Dist84: 8 Vector_XXX
+ SG_ LIDAR_Distance84 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1749 LIDAR_Dist85: 8 Vector_XXX
+ SG_ LIDAR_Distance85 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1750 LIDAR_Dist86: 8 Vector_XXX
+ SG_ LIDAR_Distance86 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1751 LIDAR_Dist87: 8 Vector_XXX
+ SG_ LIDAR_Distance87 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1752 LIDAR_Dist88: 8 Vector_XXX
+ SG_ LIDAR_Distance88 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1753 LIDAR_Dist89: 8 Vector_XXX
+ SG_ LIDAR_Distance89 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1754 LIDAR_Dist90: 8 Vector_XXX
+ SG_ LIDAR_Distance90 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1755 LIDAR_Dist91: 8 Vector_XXX
+ SG_ LIDAR_Distance91 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1756 LIDAR_Dist92: 8 Vector_XXX
+ SG_ LIDAR_Distance92 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1757 LIDAR_Dist93: 8 Vector_XXX
+ SG_ LIDAR_Distance93 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1758 LIDAR_Dist94: 8 Vector_XXX
+ SG_ LIDAR_Distance94 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1759 LIDAR_Dist95: 8 Vector_XXX
+ SG_ LIDAR_Distance95 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1760 LIDAR_Dist96: 8 Vector_XXX
+ SG_ LIDAR_Distance96 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1761 LIDAR_Dist97: 8 Vector_XXX
+ SG_ LIDAR_Distance97 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1762 LIDAR_Dist98: 8 Vector_XXX
+ SG_ LIDAR_Distance98 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1763 LIDAR_Dist99: 8 Vector_XXX
+ SG_ LIDAR_Distance99 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1764 LIDAR_Dist100: 8 Vector_XXX
+ SG_ LIDAR_Distance100 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1765 LIDAR_Dist101: 8 Vector_XXX
+ SG_ LIDAR_Distance101 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1766 LIDAR_Dist102: 8 Vector_XXX
+ SG_ LIDAR_Distance102 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1767 LIDAR_Dist103: 8 Vector_XXX
+ SG_ LIDAR_Distance103 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1768 LIDAR_Dist104: 8 Vector_XXX
+ SG_ LIDAR_Distance104 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1769 LIDAR_Dist105: 8 Vector_XXX
+ SG_ LIDAR_Distance105 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1770 LIDAR_Dist106: 8 Vector_XXX
+ SG_ LIDAR_Distance106 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1771 LIDAR_Dist107: 8 Vector_XXX
+ SG_ LIDAR_Distance107 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1772 LIDAR_Dist108: 8 Vector_XXX
+ SG_ LIDAR_Distance108 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1773 LIDAR_Dist109: 8 Vector_XXX
+ SG_ LIDAR_Distance109 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1774 LIDAR_Dist110: 8 Vector_XXX
+ SG_ LIDAR_Distance110 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1775 LIDAR_Dist111: 8 Vector_XXX
+ SG_ LIDAR_Distance111 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1776 LIDAR_Dist112: 8 Vector_XXX
+ SG_ LIDAR_Distance112 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1777 LIDAR_Dist113: 8 Vector_XXX
+ SG_ LIDAR_Distance113 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1778 LIDAR_Dist114: 8 Vector_XXX
+ SG_ LIDAR_Distance114 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1779 LIDAR_Dist115: 8 Vector_XXX
+ SG_ LIDAR_Distance115 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1780 LIDAR_Dist116: 8 Vector_XXX
+ SG_ LIDAR_Distance116 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1781 LIDAR_Dist117: 8 Vector_XXX
+ SG_ LIDAR_Distance117 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1782 LIDAR_Dist118: 8 Vector_XXX
+ SG_ LIDAR_Distance118 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1783 LIDAR_Dist119: 8 Vector_XXX
+ SG_ LIDAR_Distance119 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1784 LIDAR_Dist120: 8 Vector_XXX
+ SG_ LIDAR_Distance120 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1785 LIDAR_Dist121: 8 Vector_XXX
+ SG_ LIDAR_Distance121 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1786 LIDAR_Dist122: 8 Vector_XXX
+ SG_ LIDAR_Distance122 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1787 LIDAR_Dist123: 8 Vector_XXX
+ SG_ LIDAR_Distance123 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1788 LIDAR_Dist124: 8 Vector_XXX
+ SG_ LIDAR_Distance124 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1789 LIDAR_Dist125: 8 Vector_XXX
+ SG_ LIDAR_Distance125 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1790 LIDAR_Dist126: 8 Vector_XXX
+ SG_ LIDAR_Distance126 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1791 LIDAR_Dist127: 8 Vector_XXX
+ SG_ LIDAR_Distance127 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1792 LIDAR_Dist128: 8 Vector_XXX
+ SG_ LIDAR_Distance128 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1793 LIDAR_Dist129: 8 Vector_XXX
+ SG_ LIDAR_Distance129 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1794 LIDAR_Dist130: 8 Vector_XXX
+ SG_ LIDAR_Distance130 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1795 LIDAR_Dist131: 8 Vector_XXX
+ SG_ LIDAR_Distance131 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1796 LIDAR_Dist132: 8 Vector_XXX
+ SG_ LIDAR_Distance132 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1797 LIDAR_Dist133: 8 Vector_XXX
+ SG_ LIDAR_Distance133 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1798 LIDAR_Dist134: 8 Vector_XXX
+ SG_ LIDAR_Distance134 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1799 LIDAR_Dist135: 8 Vector_XXX
+ SG_ LIDAR_Distance135 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1800 LIDAR_Dist136: 8 Vector_XXX
+ SG_ LIDAR_Distance136 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1801 LIDAR_Dist137: 8 Vector_XXX
+ SG_ LIDAR_Distance137 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1802 LIDAR_Dist138: 8 Vector_XXX
+ SG_ LIDAR_Distance138 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1803 LIDAR_Dist139: 8 Vector_XXX
+ SG_ LIDAR_Distance139 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1804 LIDAR_Dist140: 8 Vector_XXX
+ SG_ LIDAR_Distance140 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1805 LIDAR_Dist141: 8 Vector_XXX
+ SG_ LIDAR_Distance141 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1806 LIDAR_Dist142: 8 Vector_XXX
+ SG_ LIDAR_Distance142 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1807 LIDAR_Dist143: 8 Vector_XXX
+ SG_ LIDAR_Distance143 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1808 LIDAR_Dist144: 8 Vector_XXX
+ SG_ LIDAR_Distance144 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1809 LIDAR_Dist145: 8 Vector_XXX
+ SG_ LIDAR_Distance145 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1810 LIDAR_Dist146: 8 Vector_XXX
+ SG_ LIDAR_Distance146 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1811 LIDAR_Dist147: 8 Vector_XXX
+ SG_ LIDAR_Distance147 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1812 LIDAR_Dist148: 8 Vector_XXX
+ SG_ LIDAR_Distance148 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1813 LIDAR_Dist149: 8 Vector_XXX
+ SG_ LIDAR_Distance149 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1814 LIDAR_Dist150: 8 Vector_XXX
+ SG_ LIDAR_Distance150 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1815 LIDAR_Dist151: 8 Vector_XXX
+ SG_ LIDAR_Distance151 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1816 LIDAR_Dist152: 8 Vector_XXX
+ SG_ LIDAR_Distance152 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1817 LIDAR_Dist153: 8 Vector_XXX
+ SG_ LIDAR_Distance153 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1818 LIDAR_Dist154: 8 Vector_XXX
+ SG_ LIDAR_Distance154 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1819 LIDAR_Dist155: 8 Vector_XXX
+ SG_ LIDAR_Distance155 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1820 LIDAR_Dist156: 8 Vector_XXX
+ SG_ LIDAR_Distance156 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1821 LIDAR_Dist157: 8 Vector_XXX
+ SG_ LIDAR_Distance157 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1822 LIDAR_Dist158: 8 Vector_XXX
+ SG_ LIDAR_Distance158 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1823 LIDAR_Dist159: 8 Vector_XXX
+ SG_ LIDAR_Distance159 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1824 LIDAR_Dist160: 8 Vector_XXX
+ SG_ LIDAR_Distance160 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1825 LIDAR_Dist161: 8 Vector_XXX
+ SG_ LIDAR_Distance161 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1826 LIDAR_Dist162: 8 Vector_XXX
+ SG_ LIDAR_Distance162 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1827 LIDAR_Dist163: 8 Vector_XXX
+ SG_ LIDAR_Distance163 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1828 LIDAR_Dist164: 8 Vector_XXX
+ SG_ LIDAR_Distance164 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1829 LIDAR_Dist165: 8 Vector_XXX
+ SG_ LIDAR_Distance165 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1830 LIDAR_Dist166: 8 Vector_XXX
+ SG_ LIDAR_Distance166 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1831 LIDAR_Dist167: 8 Vector_XXX
+ SG_ LIDAR_Distance167 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1832 LIDAR_Dist168: 8 Vector_XXX
+ SG_ LIDAR_Distance168 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1833 LIDAR_Dist169: 8 Vector_XXX
+ SG_ LIDAR_Distance169 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1834 LIDAR_Dist170: 8 Vector_XXX
+ SG_ LIDAR_Distance170 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1835 LIDAR_Dist171: 8 Vector_XXX
+ SG_ LIDAR_Distance171 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1836 LIDAR_Dist172: 8 Vector_XXX
+ SG_ LIDAR_Distance172 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1837 LIDAR_Dist173: 8 Vector_XXX
+ SG_ LIDAR_Distance173 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1838 LIDAR_Dist174: 8 Vector_XXX
+ SG_ LIDAR_Distance174 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1839 LIDAR_Dist175: 8 Vector_XXX
+ SG_ LIDAR_Distance175 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1840 LIDAR_Dist176: 8 Vector_XXX
+ SG_ LIDAR_Distance176 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1841 LIDAR_Dist177: 8 Vector_XXX
+ SG_ LIDAR_Distance177 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1842 LIDAR_Dist178: 8 Vector_XXX
+ SG_ LIDAR_Distance178 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1843 LIDAR_Dist179: 8 Vector_XXX
+ SG_ LIDAR_Distance179 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1844 LIDAR_Dist180: 8 Vector_XXX
+ SG_ LIDAR_Distance180 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1845 LIDAR_Dist181: 8 Vector_XXX
+ SG_ LIDAR_Distance181 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1846 LIDAR_Dist182: 8 Vector_XXX
+ SG_ LIDAR_Distance182 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1847 LIDAR_Dist183: 8 Vector_XXX
+ SG_ LIDAR_Distance183 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1848 LIDAR_Dist184: 8 Vector_XXX
+ SG_ LIDAR_Distance184 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1849 LIDAR_Dist185: 8 Vector_XXX
+ SG_ LIDAR_Distance185 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1850 LIDAR_Dist186: 8 Vector_XXX
+ SG_ LIDAR_Distance186 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1851 LIDAR_Dist187: 8 Vector_XXX
+ SG_ LIDAR_Distance187 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1852 LIDAR_Dist188: 8 Vector_XXX
+ SG_ LIDAR_Distance188 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1853 LIDAR_Dist189: 8 Vector_XXX
+ SG_ LIDAR_Distance189 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1854 LIDAR_Dist190: 8 Vector_XXX
+ SG_ LIDAR_Distance190 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1855 LIDAR_Dist191: 8 Vector_XXX
+ SG_ LIDAR_Distance191 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1856 LIDAR_Dist192: 8 Vector_XXX
+ SG_ LIDAR_Distance192 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1857 LIDAR_Dist193: 8 Vector_XXX
+ SG_ LIDAR_Distance193 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1858 LIDAR_Dist194: 8 Vector_XXX
+ SG_ LIDAR_Distance194 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1859 LIDAR_Dist195: 8 Vector_XXX
+ SG_ LIDAR_Distance195 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1860 LIDAR_Dist196: 8 Vector_XXX
+ SG_ LIDAR_Distance196 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1861 LIDAR_Dist197: 8 Vector_XXX
+ SG_ LIDAR_Distance197 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1862 LIDAR_Dist198: 8 Vector_XXX
+ SG_ LIDAR_Distance198 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1863 LIDAR_Dist199: 8 Vector_XXX
+ SG_ LIDAR_Distance199 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1864 LIDAR_Dist200: 8 Vector_XXX
+ SG_ LIDAR_Distance200 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1865 LIDAR_Dist201: 8 Vector_XXX
+ SG_ LIDAR_Distance201 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1866 LIDAR_Dist202: 8 Vector_XXX
+ SG_ LIDAR_Distance202 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1867 LIDAR_Dist203: 8 Vector_XXX
+ SG_ LIDAR_Distance203 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1868 LIDAR_Dist204: 8 Vector_XXX
+ SG_ LIDAR_Distance204 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1869 LIDAR_Dist205: 8 Vector_XXX
+ SG_ LIDAR_Distance205 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1870 LIDAR_Dist206: 8 Vector_XXX
+ SG_ LIDAR_Distance206 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1871 LIDAR_Dist207: 8 Vector_XXX
+ SG_ LIDAR_Distance207 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1872 LIDAR_Dist208: 8 Vector_XXX
+ SG_ LIDAR_Distance208 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1873 LIDAR_Dist209: 8 Vector_XXX
+ SG_ LIDAR_Distance209 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1874 LIDAR_Dist210: 8 Vector_XXX
+ SG_ LIDAR_Distance210 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1875 LIDAR_Dist211: 8 Vector_XXX
+ SG_ LIDAR_Distance211 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1876 LIDAR_Dist212: 8 Vector_XXX
+ SG_ LIDAR_Distance212 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1877 LIDAR_Dist213: 8 Vector_XXX
+ SG_ LIDAR_Distance213 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1878 LIDAR_Dist214: 8 Vector_XXX
+ SG_ LIDAR_Distance214 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1879 LIDAR_Dist215: 8 Vector_XXX
+ SG_ LIDAR_Distance215 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1880 LIDAR_Dist216: 8 Vector_XXX
+ SG_ LIDAR_Distance216 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1881 LIDAR_Dist217: 8 Vector_XXX
+ SG_ LIDAR_Distance217 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1882 LIDAR_Dist218: 8 Vector_XXX
+ SG_ LIDAR_Distance218 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1883 LIDAR_Dist219: 8 Vector_XXX
+ SG_ LIDAR_Distance219 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1884 LIDAR_Dist220: 8 Vector_XXX
+ SG_ LIDAR_Distance220 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1885 LIDAR_Dist221: 8 Vector_XXX
+ SG_ LIDAR_Distance221 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1886 LIDAR_Dist222: 8 Vector_XXX
+ SG_ LIDAR_Distance222 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1887 LIDAR_Dist223: 8 Vector_XXX
+ SG_ LIDAR_Distance223 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1888 LIDAR_Dist224: 8 Vector_XXX
+ SG_ LIDAR_Distance224 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1889 LIDAR_Dist225: 8 Vector_XXX
+ SG_ LIDAR_Distance225 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1890 LIDAR_Dist226: 8 Vector_XXX
+ SG_ LIDAR_Distance226 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1891 LIDAR_Dist227: 8 Vector_XXX
+ SG_ LIDAR_Distance227 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1892 LIDAR_Dist228: 8 Vector_XXX
+ SG_ LIDAR_Distance228 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1893 LIDAR_Dist229: 8 Vector_XXX
+ SG_ LIDAR_Distance229 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1894 LIDAR_Dist230: 8 Vector_XXX
+ SG_ LIDAR_Distance230 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1895 LIDAR_Dist231: 8 Vector_XXX
+ SG_ LIDAR_Distance231 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1896 LIDAR_Dist232: 8 Vector_XXX
+ SG_ LIDAR_Distance232 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1897 LIDAR_Dist233: 8 Vector_XXX
+ SG_ LIDAR_Distance233 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1898 LIDAR_Dist234: 8 Vector_XXX
+ SG_ LIDAR_Distance234 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1899 LIDAR_Dist235: 8 Vector_XXX
+ SG_ LIDAR_Distance235 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1900 LIDAR_Dist236: 8 Vector_XXX
+ SG_ LIDAR_Distance236 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1901 LIDAR_Dist237: 8 Vector_XXX
+ SG_ LIDAR_Distance237 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1902 LIDAR_Dist238: 8 Vector_XXX
+ SG_ LIDAR_Distance238 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1903 LIDAR_Dist239: 8 Vector_XXX
+ SG_ LIDAR_Distance239 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1904 LIDAR_Dist240: 8 Vector_XXX
+ SG_ LIDAR_Distance240 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1905 LIDAR_Dist241: 8 Vector_XXX
+ SG_ LIDAR_Distance241 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1906 LIDAR_Dist242: 8 Vector_XXX
+ SG_ LIDAR_Distance242 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1907 LIDAR_Dist243: 8 Vector_XXX
+ SG_ LIDAR_Distance243 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1908 LIDAR_Dist244: 8 Vector_XXX
+ SG_ LIDAR_Distance244 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1909 LIDAR_Dist245: 8 Vector_XXX
+ SG_ LIDAR_Distance245 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1910 LIDAR_Dist246: 8 Vector_XXX
+ SG_ LIDAR_Distance246 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1911 LIDAR_Dist247: 8 Vector_XXX
+ SG_ LIDAR_Distance247 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1912 LIDAR_Dist248: 8 Vector_XXX
+ SG_ LIDAR_Distance248 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1913 LIDAR_Dist249: 8 Vector_XXX
+ SG_ LIDAR_Distance249 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1914 LIDAR_Dist250: 8 Vector_XXX
+ SG_ LIDAR_Distance250 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1915 LIDAR_Dist251: 8 Vector_XXX
+ SG_ LIDAR_Distance251 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1916 LIDAR_Dist252: 8 Vector_XXX
+ SG_ LIDAR_Distance252 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1917 LIDAR_Dist253: 8 Vector_XXX
+ SG_ LIDAR_Distance253 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1918 LIDAR_Dist254: 8 Vector_XXX
+ SG_ LIDAR_Distance254 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1919 LIDAR_Dist255: 8 Vector_XXX
+ SG_ LIDAR_Distance255 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1920 LIDAR_Dist256: 8 Vector_XXX
+ SG_ LIDAR_Distance256 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1921 LIDAR_Dist257: 8 Vector_XXX
+ SG_ LIDAR_Distance257 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1922 LIDAR_Dist258: 8 Vector_XXX
+ SG_ LIDAR_Distance258 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1923 LIDAR_Dist259: 8 Vector_XXX
+ SG_ LIDAR_Distance259 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1924 LIDAR_Dist260: 8 Vector_XXX
+ SG_ LIDAR_Distance260 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1925 LIDAR_Dist261: 8 Vector_XXX
+ SG_ LIDAR_Distance261 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1926 LIDAR_Dist262: 8 Vector_XXX
+ SG_ LIDAR_Distance262 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1927 LIDAR_Dist263: 8 Vector_XXX
+ SG_ LIDAR_Distance263 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1928 LIDAR_Dist264: 8 Vector_XXX
+ SG_ LIDAR_Distance264 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1929 LIDAR_Dist265: 8 Vector_XXX
+ SG_ LIDAR_Distance265 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1930 LIDAR_Dist266: 8 Vector_XXX
+ SG_ LIDAR_Distance266 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1931 LIDAR_Dist267: 8 Vector_XXX
+ SG_ LIDAR_Distance267 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1932 LIDAR_Dist268: 8 Vector_XXX
+ SG_ LIDAR_Distance268 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1933 LIDAR_Dist269: 8 Vector_XXX
+ SG_ LIDAR_Distance269 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1934 LIDAR_Dist270: 8 Vector_XXX
+ SG_ LIDAR_Distance270 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1935 LIDAR_Dist271: 8 Vector_XXX
+ SG_ LIDAR_Distance271 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1936 LIDAR_Dist272: 8 Vector_XXX
+ SG_ LIDAR_Distance272 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1937 LIDAR_Dist273: 8 Vector_XXX
+ SG_ LIDAR_Distance273 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1938 LIDAR_Dist274: 8 Vector_XXX
+ SG_ LIDAR_Distance274 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1939 LIDAR_Dist275: 8 Vector_XXX
+ SG_ LIDAR_Distance275 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1940 LIDAR_Dist276: 8 Vector_XXX
+ SG_ LIDAR_Distance276 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1941 LIDAR_Dist277: 8 Vector_XXX
+ SG_ LIDAR_Distance277 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1942 LIDAR_Dist278: 8 Vector_XXX
+ SG_ LIDAR_Distance278 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1943 LIDAR_Dist279: 8 Vector_XXX
+ SG_ LIDAR_Distance279 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1944 LIDAR_Dist280: 8 Vector_XXX
+ SG_ LIDAR_Distance280 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1945 LIDAR_Dist281: 8 Vector_XXX
+ SG_ LIDAR_Distance281 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1946 LIDAR_Dist282: 8 Vector_XXX
+ SG_ LIDAR_Distance282 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1947 LIDAR_Dist283: 8 Vector_XXX
+ SG_ LIDAR_Distance283 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1948 LIDAR_Dist284: 8 Vector_XXX
+ SG_ LIDAR_Distance284 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1949 LIDAR_Dist285: 8 Vector_XXX
+ SG_ LIDAR_Distance285 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1950 LIDAR_Dist286: 8 Vector_XXX
+ SG_ LIDAR_Distance286 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1951 LIDAR_Dist287: 8 Vector_XXX
+ SG_ LIDAR_Distance287 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1952 LIDAR_Dist288: 8 Vector_XXX
+ SG_ LIDAR_Distance288 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1953 LIDAR_Dist289: 8 Vector_XXX
+ SG_ LIDAR_Distance289 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1954 LIDAR_Dist290: 8 Vector_XXX
+ SG_ LIDAR_Distance290 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1955 LIDAR_Dist291: 8 Vector_XXX
+ SG_ LIDAR_Distance291 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1956 LIDAR_Dist292: 8 Vector_XXX
+ SG_ LIDAR_Distance292 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1957 LIDAR_Dist293: 8 Vector_XXX
+ SG_ LIDAR_Distance293 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1958 LIDAR_Dist294: 8 Vector_XXX
+ SG_ LIDAR_Distance294 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1959 LIDAR_Dist295: 8 Vector_XXX
+ SG_ LIDAR_Distance295 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1960 LIDAR_Dist296: 8 Vector_XXX
+ SG_ LIDAR_Distance296 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1961 LIDAR_Dist297: 8 Vector_XXX
+ SG_ LIDAR_Distance297 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1962 LIDAR_Dist298: 8 Vector_XXX
+ SG_ LIDAR_Distance298 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1963 LIDAR_Dist299: 8 Vector_XXX
+ SG_ LIDAR_Distance299 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1964 LIDAR_Dist300: 8 Vector_XXX
+ SG_ LIDAR_Distance300 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1965 LIDAR_Dist301: 8 Vector_XXX
+ SG_ LIDAR_Distance301 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1966 LIDAR_Dist302: 8 Vector_XXX
+ SG_ LIDAR_Distance302 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1967 LIDAR_Dist303: 8 Vector_XXX
+ SG_ LIDAR_Distance303 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1968 LIDAR_Dist304: 8 Vector_XXX
+ SG_ LIDAR_Distance304 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1969 LIDAR_Dist305: 8 Vector_XXX
+ SG_ LIDAR_Distance305 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1970 LIDAR_Dist306: 8 Vector_XXX
+ SG_ LIDAR_Distance306 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1971 LIDAR_Dist307: 8 Vector_XXX
+ SG_ LIDAR_Distance307 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1972 LIDAR_Dist308: 8 Vector_XXX
+ SG_ LIDAR_Distance308 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1973 LIDAR_Dist309: 8 Vector_XXX
+ SG_ LIDAR_Distance309 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1974 LIDAR_Dist310: 8 Vector_XXX
+ SG_ LIDAR_Distance310 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1975 LIDAR_Dist311: 8 Vector_XXX
+ SG_ LIDAR_Distance311 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1976 LIDAR_Dist312: 8 Vector_XXX
+ SG_ LIDAR_Distance312 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1977 LIDAR_Dist313: 8 Vector_XXX
+ SG_ LIDAR_Distance313 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1978 LIDAR_Dist314: 8 Vector_XXX
+ SG_ LIDAR_Distance314 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1979 LIDAR_Dist315: 8 Vector_XXX
+ SG_ LIDAR_Distance315 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1980 LIDAR_Dist316: 8 Vector_XXX
+ SG_ LIDAR_Distance316 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1981 LIDAR_Dist317: 8 Vector_XXX
+ SG_ LIDAR_Distance317 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1982 LIDAR_Dist318: 8 Vector_XXX
+ SG_ LIDAR_Distance318 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1983 LIDAR_Dist319: 8 Vector_XXX
+ SG_ LIDAR_Distance319 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1984 LIDAR_Dist320: 8 Vector_XXX
+ SG_ LIDAR_Distance320 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1985 LIDAR_Dist321: 8 Vector_XXX
+ SG_ LIDAR_Distance321 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1986 LIDAR_Dist322: 8 Vector_XXX
+ SG_ LIDAR_Distance322 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1987 LIDAR_Dist323: 8 Vector_XXX
+ SG_ LIDAR_Distance323 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1988 LIDAR_Dist324: 8 Vector_XXX
+ SG_ LIDAR_Distance324 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1989 LIDAR_Dist325: 8 Vector_XXX
+ SG_ LIDAR_Distance325 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1990 LIDAR_Dist326: 8 Vector_XXX
+ SG_ LIDAR_Distance326 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1991 LIDAR_Dist327: 8 Vector_XXX
+ SG_ LIDAR_Distance327 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1992 LIDAR_Dist328: 8 Vector_XXX
+ SG_ LIDAR_Distance328 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1993 LIDAR_Dist329: 8 Vector_XXX
+ SG_ LIDAR_Distance329 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1994 LIDAR_Dist330: 8 Vector_XXX
+ SG_ LIDAR_Distance330 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1995 LIDAR_Dist331: 8 Vector_XXX
+ SG_ LIDAR_Distance331 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1996 LIDAR_Dist332: 8 Vector_XXX
+ SG_ LIDAR_Distance332 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1997 LIDAR_Dist333: 8 Vector_XXX
+ SG_ LIDAR_Distance333 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1998 LIDAR_Dist334: 8 Vector_XXX
+ SG_ LIDAR_Distance334 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 1999 LIDAR_Dist335: 8 Vector_XXX
+ SG_ LIDAR_Distance335 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2000 LIDAR_Dist336: 8 Vector_XXX
+ SG_ LIDAR_Distance336 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2001 LIDAR_Dist337: 8 Vector_XXX
+ SG_ LIDAR_Distance337 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2002 LIDAR_Dist338: 8 Vector_XXX
+ SG_ LIDAR_Distance338 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2003 LIDAR_Dist339: 8 Vector_XXX
+ SG_ LIDAR_Distance339 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2004 LIDAR_Dist340: 8 Vector_XXX
+ SG_ LIDAR_Distance340 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2005 LIDAR_Dist341: 8 Vector_XXX
+ SG_ LIDAR_Distance341 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2006 LIDAR_Dist342: 8 Vector_XXX
+ SG_ LIDAR_Distance342 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2007 LIDAR_Dist343: 8 Vector_XXX
+ SG_ LIDAR_Distance343 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2008 LIDAR_Dist344: 8 Vector_XXX
+ SG_ LIDAR_Distance344 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2009 LIDAR_Dist345: 8 Vector_XXX
+ SG_ LIDAR_Distance345 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2010 LIDAR_Dist346: 8 Vector_XXX
+ SG_ LIDAR_Distance346 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2011 LIDAR_Dist347: 8 Vector_XXX
+ SG_ LIDAR_Distance347 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2012 LIDAR_Dist348: 8 Vector_XXX
+ SG_ LIDAR_Distance348 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2013 LIDAR_Dist349: 8 Vector_XXX
+ SG_ LIDAR_Distance349 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2014 LIDAR_Dist350: 8 Vector_XXX
+ SG_ LIDAR_Distance350 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2015 LIDAR_Dist351: 8 Vector_XXX
+ SG_ LIDAR_Distance351 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2016 LIDAR_Dist352: 8 Vector_XXX
+ SG_ LIDAR_Distance352 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2017 LIDAR_Dist353: 8 Vector_XXX
+ SG_ LIDAR_Distance353 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2018 LIDAR_Dist354: 8 Vector_XXX
+ SG_ LIDAR_Distance354 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2019 LIDAR_Dist355: 8 Vector_XXX
+ SG_ LIDAR_Distance355 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2020 LIDAR_Dist356: 8 Vector_XXX
+ SG_ LIDAR_Distance356 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2021 LIDAR_Dist357: 8 Vector_XXX
+ SG_ LIDAR_Distance357 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2022 LIDAR_Dist358: 8 Vector_XXX
+ SG_ LIDAR_Distance358 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX
+BO_ 2023 LIDAR_Dist359: 8 Vector_XXX
+ SG_ LIDAR_Distance359 : 0|16@1+ (0.001,0) [0|65.535] "m" Vector_XXX

--- a/lib/vehicle-signals/vss_path.dart
+++ b/lib/vehicle-signals/vss_path.dart
@@ -94,6 +94,9 @@ class VSSPath {
       "Vehicle.Cabin.Infotainment.Navigation.DestinationSet.Longitude";
 
   // LIDAR signals
-  static const String lidarAngle = "Vehicle.ADAS.Lidar.Angle";
-  static const String lidarDistance = "Vehicle.ADAS.Lidar.Distance";
+  static const String lidarAnglePrefix = "Vehicle.ADAS.Lidar.Angle";
+  static const String lidarDistancePrefix = "Vehicle.ADAS.Lidar.Distance";
+
+  static String lidarAngle(int index) => "$lidarAnglePrefix$index";
+  static String lidarDistance(int index) => "$lidarDistancePrefix$index";
 }

--- a/lib/vehicle-signals/vss_path.dart
+++ b/lib/vehicle-signals/vss_path.dart
@@ -94,9 +94,6 @@ class VSSPath {
       "Vehicle.Cabin.Infotainment.Navigation.DestinationSet.Longitude";
 
   // LIDAR signals
-  static const String lidarAnglePrefix = "Vehicle.ADAS.Lidar.Angle";
   static const String lidarDistancePrefix = "Vehicle.ADAS.Lidar.Distance";
-
-  static String lidarAngle(int index) => "$lidarAnglePrefix$index";
   static String lidarDistance(int index) => "$lidarDistancePrefix$index";
 }

--- a/lib/vehicle-signals/vss_provider.dart
+++ b/lib/vehicle-signals/vss_provider.dart
@@ -286,8 +286,9 @@ class DashboardVssClient extends VssClient {
               break;
             }
           }
+        } else {
+          print("ERROR: Unexpected path ${update.entry.path}");
         }
-        print("ERROR: Unexpected path ${update.entry.path}");
         break;
     }
   }

--- a/lib/vehicle-signals/vss_provider.dart
+++ b/lib/vehicle-signals/vss_provider.dart
@@ -36,23 +36,21 @@ class DashboardVssClient extends VssClient {
     VSSPath.vehicleBatteryChargingStatus,
     VSSPath.vehicleDistanceUnit,
     VSSPath.vehicleTemperatureUnit,
-    for (var i = 0; i < 360; i++) VSSPath.lidarAngle(i),
     for (var i = 0; i < 360; i++) VSSPath.lidarDistance(i),
     VSSPath.steeringCruiseEnable,
     VSSPath.steeringCruiseSet,
     VSSPath.steeringCruiseResume,
     VSSPath.steeringCruiseCancel,
     VSSPath.steeringInfo,
-    VSSPath.steeringLaneDepWarn,
+    VSSPath.steeringLaneDepWarn
   ];
 
-  final List<double> _angles = List.filled(360, 0);
   final List<double> _distances = List.filled(360, 0);
 
   void _publishLidarIfReady() {
     final points = List.generate(
       360,
-      (i) => LidarPoint(angle: _angles[i], distance: _distances[i]),
+      (i) => LidarPoint(angle: i.toDouble(), distance: _distances[i]),
     );
     ref.read(lidarProvider.notifier).update(points);
   }
@@ -277,18 +275,7 @@ class DashboardVssClient extends VssClient {
 
       default:
         final path = update.entry.path;
-        if (path.startsWith(VSSPath.lidarAnglePrefix)) {
-          if (update.entry.value.hasFloat()) {
-            final idx = int.tryParse(
-                  path.substring(VSSPath.lidarAnglePrefix.length)) ??
-                -1;
-            if (idx >= 0 && idx < 360) {
-              _angles[idx] = update.entry.value.float;
-              _publishLidarIfReady();
-              break;
-            }
-          }
-        } else if (path.startsWith(VSSPath.lidarDistancePrefix)) {
+        if (path.startsWith(VSSPath.lidarDistancePrefix)) {
           if (update.entry.value.hasFloat()) {
             final idx = int.tryParse(
                   path.substring(VSSPath.lidarDistancePrefix.length)) ??

--- a/lib/vehicle-signals/vss_provider.dart
+++ b/lib/vehicle-signals/vss_provider.dart
@@ -36,36 +36,33 @@ class DashboardVssClient extends VssClient {
     VSSPath.vehicleBatteryChargingStatus,
     VSSPath.vehicleDistanceUnit,
     VSSPath.vehicleTemperatureUnit,
-    VSSPath.lidarAngle,
-    VSSPath.lidarDistance,
+    for (var i = 0; i < 360; i++) VSSPath.lidarAngle(i),
+    for (var i = 0; i < 360; i++) VSSPath.lidarDistance(i),
     VSSPath.steeringCruiseEnable,
     VSSPath.steeringCruiseSet,
     VSSPath.steeringCruiseResume,
     VSSPath.steeringCruiseCancel,
     VSSPath.steeringInfo,
-    VSSPath.steeringLaneDepWarn
+    VSSPath.steeringLaneDepWarn,
   ];
 
-  List<double>? _angles;
-  List<double>? _distances;
+  final List<double> _angles = List.filled(360, 0);
+  final List<double> _distances = List.filled(360, 0);
 
   void _publishLidarIfReady() {
-    if (_angles == null || _distances == null) return;
-    final int len = _angles!.length < _distances!.length
-        ? _angles!.length
-        : _distances!.length;
-    final points = <LidarPoint>[];
-    for (var i = 0; i < len; i++) {
-      points.add(LidarPoint(angle: _angles![i], distance: _distances![i]));
-    }
+    final points = List.generate(
+      360,
+      (i) => LidarPoint(angle: _angles[i], distance: _distances[i]),
+    );
     ref.read(lidarProvider.notifier).update(points);
   }
 
-  DashboardVssClient(
-      {required super.config,
-      required super.channel,
-      required super.stub,
-      required super.ref});
+  DashboardVssClient({
+    required super.config,
+    required super.channel,
+    required super.stub,
+    required super.ref,
+  });
 
   static String? numToGear(int? number) {
     switch (number) {
@@ -154,7 +151,8 @@ class DashboardVssClient extends VssClient {
       case VSSPath.vehicleSelectedGear:
         if (update.entry.value.hasInt32()) {
           vehicleStatus.update(
-              selectedGear: numToGear(update.entry.value.int32));
+            selectedGear: numToGear(update.entry.value.int32),
+          );
         }
         break;
       case VSSPath.vehiclePerformanceMode:
@@ -185,7 +183,8 @@ class DashboardVssClient extends VssClient {
       case VSSPath.vehicleCruiseControlError:
         if (update.entry.value.hasBool_12()) {
           vehicleStatus.update(
-              isCruiseControlError: update.entry.value.bool_12);
+            isCruiseControlError: update.entry.value.bool_12,
+          );
         }
         break;
       case VSSPath.vehicleCruiseControlSpeedSet:
@@ -196,7 +195,8 @@ class DashboardVssClient extends VssClient {
       case VSSPath.vehicleCruiseControlActive:
         if (update.entry.value.hasBool_12()) {
           vehicleStatus.update(
-              isCruiseControlActive: update.entry.value.bool_12);
+            isCruiseControlActive: update.entry.value.bool_12,
+          );
         }
         break;
       case VSSPath.vehicleBatteryChargingStatus:
@@ -217,20 +217,6 @@ class DashboardVssClient extends VssClient {
           if (update.entry.value.string == "F")
             unit = TemperatureUnit.fahrenheit;
           vehicleStatus.update(temperatureUnit: unit);
-        }
-        break;
-      case VSSPath.lidarAngle:
-        if (update.entry.value.hasFloat()) {                   // ← チェックを変更
-          final angle = update.entry.value.float;              // ← 単一値を取得
-          _angles = [angle];                                   // ← 長さ1の List に
-          _publishLidarIfReady();
-        }
-        break;
-      case VSSPath.lidarDistance:
-        if (update.entry.value.hasFloat()) {
-          final dist = update.entry.value.float;
-          _distances = [dist];
-          _publishLidarIfReady();
         }
         break;
       // Steering wheel switches
@@ -273,7 +259,8 @@ class DashboardVssClient extends VssClient {
         if (update.entry.value.hasBool_12()) {
           if (update.entry.value.bool_12) {
             vehicleStatus.update(
-                isSteeringInfo: !vehicleStatus.state.isSteeringInfo);
+              isSteeringInfo: !vehicleStatus.state.isSteeringInfo,
+            );
           }
         }
         break;
@@ -281,13 +268,38 @@ class DashboardVssClient extends VssClient {
         if (update.entry.value.hasBool_12()) {
           if (update.entry.value.bool_12) {
             vehicleStatus.update(
-                isSteeringLaneWarning:
-                    !(vehicleStatus.state.isSteeringLaneWarning));
+              isSteeringLaneWarning:
+                  !(vehicleStatus.state.isSteeringLaneWarning),
+            );
           }
         }
         break;
 
       default:
+        final path = update.entry.path;
+        if (path.startsWith(VSSPath.lidarAnglePrefix)) {
+          if (update.entry.value.hasFloat()) {
+            final idx = int.tryParse(
+                  path.substring(VSSPath.lidarAnglePrefix.length)) ??
+                -1;
+            if (idx >= 0 && idx < 360) {
+              _angles[idx] = update.entry.value.float;
+              _publishLidarIfReady();
+              break;
+            }
+          }
+        } else if (path.startsWith(VSSPath.lidarDistancePrefix)) {
+          if (update.entry.value.hasFloat()) {
+            final idx = int.tryParse(
+                  path.substring(VSSPath.lidarDistancePrefix.length)) ??
+                -1;
+            if (idx >= 0 && idx < 360) {
+              _distances[idx] = update.entry.value.float;
+              _publishLidarIfReady();
+              break;
+            }
+          }
+        }
         print("ERROR: Unexpected path ${update.entry.path}");
         break;
     }
@@ -302,18 +314,26 @@ final vssClientProvider = Provider((ref) {
     print("Using TLS");
     if (config.tls_server_name.isNotEmpty)
       creds = ChannelCredentials.secure(
-          certificates: config.ca_certificate,
-          authority: config.tls_server_name);
+        certificates: config.ca_certificate,
+        authority: config.tls_server_name,
+      );
     else
       creds = ChannelCredentials.secure(certificates: config.ca_certificate);
   } else {
     creds = ChannelCredentials.insecure();
   }
-  final channel = ClientChannel(config.hostname,
-      port: config.port, options: ChannelOptions(credentials: creds));
+  final channel = ClientChannel(
+    config.hostname,
+    port: config.port,
+    options: ChannelOptions(credentials: creds),
+  );
 
   final stub = VALClient(channel);
 
   return DashboardVssClient(
-      config: config, channel: channel, stub: stub, ref: ref);
+    config: config,
+    channel: channel,
+    stub: stub,
+    ref: ref,
+  );
 });

--- a/simple-can-simulator.py
+++ b/simple-can-simulator.py
@@ -386,8 +386,8 @@ class LidarMessageSender(object):
                 #   LIDAR_Distance : 0.001 m/bit
                 angle_raw = int(angle / 0.01)
                 distance_raw = int(distance / 0.001)
-                data = struct.pack('<HH', angle_raw, distance_raw)
-                self.can_sock.send(0x680, data, 0)
+                data = struct.pack('<H', distance_raw)
+                self.can_sock.send(0x680 + angle, data, 0)
                 self._idx += 1
 
             # Advance the phase for the next batch

--- a/vss_5.0-agl.json
+++ b/vss_5.0-agl.json
@@ -278,9365 +278,4325 @@
           },
           "Lidar": {
             "children": {
-              "Angle0": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle1": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle2": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle3": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle4": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle5": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle6": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle7": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle8": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle9": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle10": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle11": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle12": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle13": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle14": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle15": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle16": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle17": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle18": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle19": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle20": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle21": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle22": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle23": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle24": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle25": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle26": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle27": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle28": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle29": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle30": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle31": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle32": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle33": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle34": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle35": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle36": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle37": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle38": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle39": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle40": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle41": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle42": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle43": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle44": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle45": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle46": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle47": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle48": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle49": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle50": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle51": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle52": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle53": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle54": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle55": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle56": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle57": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle58": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle59": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle60": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle61": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle62": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle63": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle64": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle65": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle66": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle67": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle68": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle69": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle70": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle71": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle72": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle73": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle74": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle75": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle76": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle77": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle78": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle79": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle80": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle81": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle82": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle83": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle84": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle85": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle86": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle87": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle88": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle89": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle90": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle91": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle92": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle93": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle94": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle95": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle96": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle97": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle98": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle99": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle100": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle101": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle102": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle103": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle104": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle105": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle106": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle107": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle108": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle109": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle110": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle111": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle112": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle113": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle114": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle115": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle116": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle117": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle118": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle119": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle120": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle121": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle122": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle123": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle124": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle125": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle126": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle127": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle128": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle129": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle130": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle131": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle132": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle133": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle134": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle135": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle136": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle137": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle138": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle139": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle140": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle141": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle142": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle143": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle144": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle145": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle146": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle147": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle148": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle149": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle150": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle151": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle152": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle153": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle154": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle155": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle156": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle157": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle158": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle159": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle160": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle161": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle162": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle163": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle164": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle165": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle166": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle167": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle168": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle169": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle170": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle171": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle172": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle173": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle174": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle175": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle176": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle177": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle178": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle179": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle180": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle181": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle182": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle183": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle184": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle185": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle186": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle187": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle188": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle189": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle190": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle191": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle192": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle193": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle194": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle195": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle196": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle197": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle198": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle199": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle200": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle201": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle202": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle203": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle204": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle205": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle206": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle207": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle208": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle209": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle210": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle211": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle212": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle213": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle214": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle215": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle216": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle217": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle218": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle219": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle220": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle221": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle222": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle223": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle224": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle225": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle226": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle227": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle228": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle229": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle230": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle231": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle232": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle233": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle234": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle235": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle236": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle237": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle238": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle239": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle240": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle241": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle242": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle243": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle244": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle245": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle246": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle247": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle248": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle249": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle250": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle251": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle252": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle253": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle254": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle255": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle256": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle257": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle258": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle259": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle260": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle261": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle262": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle263": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle264": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle265": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle266": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle267": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle268": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle269": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle270": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle271": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle272": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle273": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle274": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle275": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle276": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle277": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle278": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle279": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle280": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle281": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle282": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle283": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle284": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle285": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle286": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle287": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle288": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle289": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle290": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle291": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle292": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle293": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle294": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle295": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle296": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle297": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle298": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle299": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle300": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle301": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle302": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle303": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle304": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle305": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle306": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle307": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle308": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle309": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle310": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle311": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle312": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle313": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle314": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle315": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle316": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle317": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle318": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle319": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle320": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle321": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle322": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle323": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle324": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle325": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle326": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle327": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle328": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle329": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle330": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle331": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle332": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle333": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle334": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle335": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle336": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle337": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle338": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle339": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle340": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle341": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle342": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle343": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle344": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle345": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle346": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle347": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle348": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle349": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle350": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle351": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle352": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle353": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle354": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle355": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle356": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle357": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle358": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
-              "Angle359": {
-                "datatype": "float",
-                "dbc2vss": {
-                  "interval_ms": 100,
-                  "signal": "LIDAR_Angle"
-                },
-                "description": "Lidar scan angle.",
-                "type": "sensor",
-                "unit": "degrees",
-                "vss2dbc": {
-                  "signal": "LidarAngles"
-                }
-              },
               "Distance0": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance0"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance1": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance1"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance2": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance2"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance3": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance3"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance4": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance4"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance5": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance5"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance6": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance6"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance7": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance7"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance8": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance8"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance9": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance9"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance10": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance10"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance11": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance11"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance12": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance12"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance13": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance13"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance14": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance14"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance15": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance15"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance16": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance16"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance17": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance17"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance18": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance18"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance19": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance19"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance20": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance20"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance21": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance21"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance22": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance22"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance23": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance23"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance24": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance24"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance25": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance25"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance26": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance26"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance27": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance27"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance28": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance28"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance29": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance29"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance30": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance30"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance31": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance31"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance32": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance32"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance33": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance33"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance34": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance34"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance35": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance35"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance36": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance36"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance37": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance37"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance38": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance38"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance39": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance39"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance40": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance40"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance41": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance41"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance42": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance42"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance43": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance43"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance44": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance44"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance45": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance45"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance46": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance46"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance47": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance47"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance48": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance48"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance49": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance49"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance50": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance50"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance51": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance51"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance52": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance52"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance53": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance53"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance54": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance54"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance55": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance55"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance56": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance56"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance57": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance57"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance58": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance58"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance59": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance59"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance60": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance60"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance61": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance61"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance62": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance62"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance63": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance63"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance64": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance64"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance65": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance65"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance66": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance66"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance67": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance67"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance68": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance68"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance69": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance69"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance70": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance70"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance71": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance71"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance72": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance72"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance73": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance73"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance74": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance74"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance75": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance75"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance76": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance76"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance77": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance77"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance78": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance78"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance79": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance79"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance80": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance80"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance81": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance81"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance82": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance82"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance83": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance83"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance84": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance84"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance85": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance85"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance86": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance86"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance87": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance87"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance88": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance88"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance89": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance89"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance90": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance90"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance91": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance91"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance92": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance92"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance93": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance93"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance94": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance94"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance95": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance95"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance96": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance96"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance97": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance97"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance98": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance98"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance99": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance99"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance100": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance100"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance101": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance101"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance102": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance102"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance103": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance103"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance104": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance104"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance105": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance105"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance106": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance106"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance107": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance107"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance108": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance108"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance109": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance109"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance110": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance110"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance111": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance111"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance112": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance112"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance113": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance113"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance114": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance114"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance115": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance115"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance116": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance116"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance117": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance117"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance118": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance118"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance119": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance119"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance120": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance120"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance121": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance121"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance122": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance122"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance123": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance123"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance124": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance124"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance125": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance125"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance126": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance126"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance127": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance127"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance128": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance128"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance129": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance129"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance130": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance130"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance131": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance131"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance132": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance132"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance133": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance133"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance134": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance134"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance135": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance135"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance136": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance136"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance137": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance137"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance138": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance138"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance139": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance139"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance140": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance140"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance141": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance141"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance142": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance142"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance143": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance143"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance144": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance144"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance145": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance145"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance146": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance146"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance147": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance147"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance148": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance148"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance149": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance149"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance150": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance150"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance151": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance151"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance152": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance152"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance153": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance153"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance154": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance154"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance155": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance155"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance156": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance156"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance157": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance157"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance158": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance158"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance159": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance159"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance160": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance160"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance161": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance161"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance162": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance162"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance163": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance163"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance164": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance164"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance165": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance165"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance166": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance166"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance167": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance167"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance168": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance168"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance169": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance169"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance170": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance170"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance171": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance171"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance172": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance172"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance173": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance173"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance174": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance174"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance175": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance175"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance176": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance176"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance177": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance177"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance178": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance178"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance179": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance179"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance180": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance180"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance181": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance181"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance182": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance182"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance183": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance183"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance184": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance184"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance185": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance185"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance186": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance186"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance187": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance187"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance188": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance188"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance189": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance189"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance190": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance190"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance191": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance191"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance192": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance192"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance193": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance193"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance194": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance194"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance195": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance195"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance196": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance196"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance197": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance197"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance198": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance198"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance199": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance199"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance200": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance200"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance201": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance201"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance202": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance202"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance203": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance203"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance204": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance204"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance205": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance205"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance206": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance206"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance207": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance207"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance208": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance208"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance209": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance209"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance210": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance210"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance211": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance211"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance212": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance212"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance213": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance213"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance214": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance214"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance215": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance215"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance216": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance216"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance217": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance217"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance218": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance218"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance219": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance219"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance220": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance220"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance221": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance221"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance222": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance222"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance223": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance223"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance224": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance224"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance225": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance225"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance226": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance226"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance227": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance227"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance228": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance228"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance229": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance229"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance230": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance230"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance231": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance231"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance232": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance232"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance233": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance233"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance234": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance234"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance235": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance235"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance236": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance236"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance237": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance237"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance238": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance238"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance239": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance239"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance240": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance240"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance241": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance241"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance242": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance242"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance243": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance243"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance244": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance244"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance245": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance245"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance246": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance246"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance247": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance247"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance248": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance248"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance249": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance249"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance250": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance250"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance251": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance251"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance252": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance252"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance253": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance253"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance254": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance254"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance255": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance255"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance256": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance256"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance257": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance257"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance258": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance258"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance259": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance259"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance260": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance260"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance261": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance261"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance262": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance262"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance263": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance263"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance264": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance264"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance265": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance265"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance266": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance266"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance267": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance267"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance268": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance268"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance269": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance269"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance270": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance270"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance271": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance271"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance272": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance272"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance273": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance273"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance274": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance274"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance275": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance275"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance276": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance276"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance277": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance277"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance278": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance278"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance279": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance279"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance280": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance280"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance281": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance281"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance282": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance282"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance283": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance283"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance284": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance284"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance285": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance285"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance286": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance286"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance287": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance287"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance288": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance288"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance289": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance289"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance290": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance290"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance291": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance291"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance292": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance292"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance293": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance293"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance294": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance294"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance295": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance295"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance296": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance296"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance297": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance297"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance298": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance298"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance299": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance299"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance300": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance300"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance301": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance301"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance302": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance302"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance303": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance303"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance304": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance304"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance305": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance305"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance306": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance306"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance307": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance307"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance308": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance308"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance309": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance309"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance310": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance310"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance311": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance311"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance312": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance312"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance313": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance313"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance314": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance314"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance315": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance315"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance316": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance316"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance317": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance317"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance318": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance318"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance319": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance319"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance320": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance320"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance321": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance321"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance322": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance322"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance323": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance323"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance324": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance324"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance325": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance325"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance326": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance326"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance327": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance327"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance328": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance328"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance329": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance329"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance330": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance330"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance331": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance331"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance332": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance332"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance333": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance333"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance334": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance334"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance335": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance335"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance336": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance336"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance337": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance337"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance338": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance338"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance339": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance339"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance340": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance340"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance341": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance341"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance342": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance342"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance343": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance343"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance344": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance344"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance345": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance345"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance346": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance346"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance347": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance347"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance348": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance348"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance349": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance349"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance350": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance350"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance351": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance351"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance352": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance352"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance353": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance353"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance354": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance354"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance355": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance355"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance356": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance356"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance357": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance357"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance358": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance358"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               },
               "Distance359": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
-                  "signal": "LIDAR_Distance"
+                  "signal": "LIDAR_Distance359"
                 },
                 "description": "Lidar scan distance.",
                 "type": "sensor",
-                "unit": "m",
-                "vss2dbc": {
-                  "signal": "LidarDistances"
-                }
+                "factor":  0.001,
+                "offset":  0,
+                "unit": "m"
               }
             },
             "description": "Lidar sensor data.",

--- a/vss_5.0-agl.json
+++ b/vss_5.0-agl.json
@@ -278,26 +278,9360 @@
           },
           "Lidar": {
             "children": {
-              "Angle": {
+              "Angle0": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
                   "signal": "LIDAR_Angle"
                 },
-                "description": "Array of lidar scan angles.",
+                "description": "Lidar scan angle.",
                 "type": "sensor",
                 "unit": "degrees",
                 "vss2dbc": {
                   "signal": "LidarAngles"
                 }
               },
-              "Distance": {
+              "Angle1": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle2": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle3": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle4": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle5": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle6": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle7": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle8": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle9": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle10": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle11": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle12": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle13": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle14": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle15": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle16": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle17": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle18": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle19": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle20": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle21": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle22": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle23": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle24": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle25": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle26": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle27": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle28": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle29": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle30": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle31": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle32": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle33": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle34": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle35": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle36": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle37": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle38": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle39": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle40": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle41": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle42": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle43": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle44": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle45": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle46": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle47": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle48": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle49": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle50": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle51": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle52": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle53": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle54": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle55": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle56": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle57": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle58": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle59": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle60": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle61": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle62": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle63": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle64": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle65": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle66": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle67": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle68": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle69": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle70": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle71": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle72": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle73": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle74": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle75": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle76": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle77": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle78": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle79": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle80": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle81": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle82": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle83": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle84": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle85": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle86": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle87": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle88": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle89": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle90": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle91": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle92": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle93": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle94": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle95": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle96": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle97": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle98": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle99": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle100": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle101": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle102": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle103": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle104": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle105": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle106": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle107": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle108": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle109": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle110": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle111": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle112": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle113": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle114": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle115": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle116": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle117": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle118": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle119": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle120": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle121": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle122": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle123": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle124": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle125": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle126": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle127": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle128": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle129": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle130": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle131": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle132": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle133": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle134": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle135": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle136": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle137": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle138": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle139": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle140": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle141": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle142": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle143": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle144": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle145": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle146": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle147": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle148": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle149": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle150": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle151": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle152": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle153": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle154": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle155": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle156": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle157": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle158": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle159": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle160": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle161": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle162": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle163": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle164": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle165": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle166": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle167": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle168": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle169": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle170": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle171": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle172": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle173": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle174": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle175": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle176": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle177": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle178": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle179": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle180": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle181": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle182": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle183": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle184": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle185": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle186": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle187": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle188": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle189": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle190": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle191": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle192": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle193": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle194": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle195": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle196": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle197": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle198": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle199": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle200": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle201": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle202": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle203": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle204": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle205": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle206": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle207": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle208": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle209": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle210": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle211": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle212": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle213": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle214": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle215": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle216": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle217": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle218": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle219": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle220": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle221": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle222": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle223": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle224": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle225": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle226": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle227": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle228": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle229": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle230": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle231": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle232": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle233": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle234": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle235": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle236": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle237": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle238": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle239": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle240": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle241": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle242": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle243": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle244": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle245": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle246": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle247": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle248": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle249": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle250": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle251": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle252": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle253": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle254": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle255": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle256": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle257": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle258": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle259": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle260": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle261": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle262": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle263": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle264": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle265": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle266": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle267": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle268": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle269": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle270": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle271": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle272": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle273": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle274": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle275": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle276": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle277": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle278": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle279": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle280": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle281": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle282": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle283": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle284": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle285": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle286": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle287": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle288": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle289": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle290": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle291": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle292": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle293": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle294": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle295": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle296": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle297": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle298": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle299": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle300": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle301": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle302": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle303": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle304": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle305": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle306": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle307": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle308": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle309": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle310": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle311": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle312": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle313": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle314": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle315": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle316": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle317": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle318": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle319": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle320": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle321": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle322": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle323": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle324": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle325": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle326": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle327": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle328": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle329": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle330": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle331": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle332": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle333": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle334": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle335": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle336": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle337": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle338": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle339": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle340": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle341": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle342": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle343": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle344": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle345": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle346": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle347": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle348": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle349": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle350": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle351": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle352": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle353": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle354": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle355": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle356": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle357": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle358": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Angle359": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Angle"
+                },
+                "description": "Lidar scan angle.",
+                "type": "sensor",
+                "unit": "degrees",
+                "vss2dbc": {
+                  "signal": "LidarAngles"
+                }
+              },
+              "Distance0": {
                 "datatype": "float",
                 "dbc2vss": {
                   "interval_ms": 100,
                   "signal": "LIDAR_Distance"
                 },
-                "description": "Array of lidar scan distances.",
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance1": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance2": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance3": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance4": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance5": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance6": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance7": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance8": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance9": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance10": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance11": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance12": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance13": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance14": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance15": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance16": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance17": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance18": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance19": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance20": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance21": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance22": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance23": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance24": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance25": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance26": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance27": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance28": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance29": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance30": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance31": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance32": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance33": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance34": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance35": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance36": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance37": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance38": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance39": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance40": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance41": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance42": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance43": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance44": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance45": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance46": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance47": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance48": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance49": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance50": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance51": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance52": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance53": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance54": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance55": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance56": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance57": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance58": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance59": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance60": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance61": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance62": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance63": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance64": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance65": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance66": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance67": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance68": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance69": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance70": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance71": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance72": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance73": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance74": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance75": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance76": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance77": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance78": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance79": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance80": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance81": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance82": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance83": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance84": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance85": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance86": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance87": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance88": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance89": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance90": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance91": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance92": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance93": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance94": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance95": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance96": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance97": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance98": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance99": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance100": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance101": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance102": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance103": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance104": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance105": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance106": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance107": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance108": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance109": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance110": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance111": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance112": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance113": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance114": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance115": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance116": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance117": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance118": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance119": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance120": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance121": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance122": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance123": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance124": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance125": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance126": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance127": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance128": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance129": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance130": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance131": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance132": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance133": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance134": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance135": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance136": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance137": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance138": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance139": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance140": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance141": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance142": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance143": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance144": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance145": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance146": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance147": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance148": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance149": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance150": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance151": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance152": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance153": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance154": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance155": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance156": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance157": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance158": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance159": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance160": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance161": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance162": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance163": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance164": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance165": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance166": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance167": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance168": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance169": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance170": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance171": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance172": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance173": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance174": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance175": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance176": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance177": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance178": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance179": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance180": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance181": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance182": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance183": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance184": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance185": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance186": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance187": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance188": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance189": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance190": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance191": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance192": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance193": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance194": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance195": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance196": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance197": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance198": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance199": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance200": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance201": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance202": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance203": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance204": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance205": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance206": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance207": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance208": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance209": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance210": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance211": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance212": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance213": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance214": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance215": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance216": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance217": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance218": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance219": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance220": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance221": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance222": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance223": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance224": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance225": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance226": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance227": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance228": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance229": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance230": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance231": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance232": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance233": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance234": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance235": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance236": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance237": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance238": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance239": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance240": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance241": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance242": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance243": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance244": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance245": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance246": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance247": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance248": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance249": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance250": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance251": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance252": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance253": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance254": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance255": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance256": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance257": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance258": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance259": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance260": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance261": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance262": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance263": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance264": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance265": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance266": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance267": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance268": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance269": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance270": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance271": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance272": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance273": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance274": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance275": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance276": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance277": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance278": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance279": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance280": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance281": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance282": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance283": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance284": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance285": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance286": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance287": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance288": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance289": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance290": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance291": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance292": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance293": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance294": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance295": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance296": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance297": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance298": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance299": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance300": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance301": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance302": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance303": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance304": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance305": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance306": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance307": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance308": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance309": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance310": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance311": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance312": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance313": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance314": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance315": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance316": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance317": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance318": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance319": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance320": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance321": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance322": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance323": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance324": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance325": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance326": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance327": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance328": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance329": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance330": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance331": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance332": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance333": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance334": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance335": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance336": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance337": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance338": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance339": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance340": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance341": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance342": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance343": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance344": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance345": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance346": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance347": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance348": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance349": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance350": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance351": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance352": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance353": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance354": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance355": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance356": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance357": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance358": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
+                "type": "sensor",
+                "unit": "m",
+                "vss2dbc": {
+                  "signal": "LidarDistances"
+                }
+              },
+              "Distance359": {
+                "datatype": "float",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "LIDAR_Distance"
+                },
+                "description": "Lidar scan distance.",
                 "type": "sensor",
                 "unit": "m",
                 "vss2dbc": {


### PR DESCRIPTION
## Summary
- expose lidar paths for 360 angles and distances
- hold lidar points in arrays and update from indexed signals
- expand VSS data so Lidar.Angle0-359 and Distance0-359 are defined

## Testing
- `dart format lib/vehicle-signals/vss_provider.dart` *(fails: command not found)*
- `dart analyze lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540ca4122083229000990e0465a289