### PR TITLE
Fix Lidar data handling

### DIFF
--- a/lib/vehicle-signals/vss_provider.dart
+++ b/lib/vehicle-signals/vss_provider.dart
@@ -276,12 +276,16 @@ class DashboardVssClient extends VssClient {
       default:
         final path = update.entry.path;
         if (path.startsWith(VSSPath.lidarDistancePrefix)) {
-          if (update.entry.value.hasFloat()) {
+          if (update.entry.value.hasFloat() ||
+              update.entry.value.hasDouble_18()) {
             final idx = int.tryParse(
                   path.substring(VSSPath.lidarDistancePrefix.length)) ??
                 -1;
             if (idx >= 0 && idx < 360) {
-              _distances[idx] = update.entry.value.float;
+              final distance = update.entry.value.hasFloat()
+                  ? update.entry.value.float
+                  : update.entry.value.double_18;
+              _distances[idx] = distance;
               _publishLidarIfReady();
               break;
             }


### PR DESCRIPTION
## Summary
- handle lidar distance values encoded as `double` in `vss_provider.dart`

## Testing
- `./flutter/bin/flutter analyze` *(fails: resolving dependencies requires network)*

------
https://chatgpt.com/codex/tasks/task_e_68546fe4b49c8322b573841946441794